### PR TITLE
Fixing issue with multiple brackets in phExpr region

### DIFF
--- a/syntax/play2-html.vim
+++ b/syntax/play2-html.vim
@@ -27,9 +27,9 @@ syn match phExprIdentifier /@[A-Za-z0-9.]\+/ nextgroup=phExpr
 syn region phComment start=/@[*]/ end=/[*]@/
 syn match phOverrided      "@@"
 
-syn region phExpr matchgroup=phExprIdentifier start="("  end=")"  contains=@scala contained nextgroup=phExpr
-syn region phExpr matchgroup=phExprIdentifier start="{"  end="}"  contains=@scala contained nextgroup=phExpr
-syn region phExpr matchgroup=phExprIdentifier start="\[" end="\]" contains=@scala contained nextgroup=phExpr
+syn region phExpr matchgroup=phExprIdentifier start="("  end=")"  contains=@scala,phExpr contained nextgroup=phExpr
+syn region phExpr matchgroup=phExprIdentifier start="{"  end="}"  contains=@scala,phExpr contained nextgroup=phExpr
+syn region phExpr matchgroup=phExprIdentifier start="\[" end="\]" contains=@scala,phExpr contained nextgroup=phExpr
 syn region htmlTag   start=+<[^/%]+ end=+>+ contains=htmlTagN,htmlString,htmlArg,htmlValue,htmlTagError,htmlEvent,htmlCssDefinition,@htmlPreproc,@htmlArgCluster,phExpr
 
 " Define the default highlighting.


### PR DESCRIPTION
In play views, if a phExpr syntax region had extra brackets in then the
syntax highlighting did not work correctly.

e.g.

```
@for((foo, number) <- fooList.view.zipWithIndex) {
    <div>@(foo) is number @(number)</div>
}
```

the extra brackets around foo,number in the for loop would cause
problems.

By changing the phExpr region definition so that it can contain other
phExpr regions this seems to fix the problem.
